### PR TITLE
fix: pad base64 CA cert decoding

### DIFF
--- a/backend/db/migrate.js
+++ b/backend/db/migrate.js
@@ -30,7 +30,12 @@ if (!ca) {
   const caB64Env = caB64EnvRaw && stripQuotes(caB64EnvRaw);
   if (caB64Env) {
     try {
-      ca = Buffer.from(String(caB64Env).replace(/\s+/g, ''), 'base64').toString('utf8');
+      const sanitized = String(caB64Env).replace(/\s+/g, '');
+      const padded = sanitized.padEnd(
+        sanitized.length + ((4 - (sanitized.length % 4)) % 4),
+        '='
+      );
+      ca = Buffer.from(padded, 'base64').toString('utf8');
     } catch (_) {
       // ignore
     }


### PR DESCRIPTION
## Summary
- handle missing padding when decoding base64 CA certs in migration script

## Testing
- `npm test`
- `npx eslint db/migrate.js`
- `npm run lint` *(fails: `audit-render.js` redundant boolean call, `audit-supabase.js` unused var)*


------
https://chatgpt.com/codex/tasks/task_e_68c5d5d9eb10832ea18c33b4a5aa4e84