### PR TITLE
fix: pad base64 CA cert decoding

### DIFF
--- a/backend/scripts/audit-render.js
+++ b/backend/scripts/audit-render.js
@@ -34,7 +34,7 @@ function api(path) {
   });
 }
 
-function flag(val) { return Boolean(val) ? 'set' : 'missing'; }
+  function flag(val) { return val ? 'set' : 'missing'; }
 
 async function main() {
   const service = await api('');

--- a/backend/scripts/audit-supabase.js
+++ b/backend/scripts/audit-supabase.js
@@ -224,11 +224,11 @@ async function main() {
     printRows(policies, 'No policies found');
 
     // Expected RLS tables
-    printSection('Expected RLS tables status');
     const expectedTables = ['items','sequences','causals','partners','addresses'];
+    const valuesList = expectedTables.map(t => `('${t}')`).join(',');
     const expectedStatus = await runQuery(
       client,
-      `with expected(tablename) as (values ('items'),('sequences'),('causals'),('partners'),('addresses'))
+      `with expected(tablename) as (values ${valuesList})
        select e.tablename,
               case when c.oid is null or n.nspname <> 'public' then 'MISSING_TABLE'
                    when c.relrowsecurity=false then 'RLS_DISABLED'


### PR DESCRIPTION
## Summary
- handle missing padding when decoding base64 CA certs in migration script
- retain Node's root certificates when supplying custom DB CA and log decode failures
- clean up audit scripts to satisfy eslint

## Testing
- `npm test`
- `npx eslint scripts/audit-render.js scripts/audit-supabase.js db/migrate.js`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5d5d9eb10832ea18c33b4a5aa4e84