### PR TITLE
docs: note single Render service

### DIFF
--- a/PROJECT_INSTRUCTIONS.md
+++ b/PROJECT_INSTRUCTIONS.md
@@ -72,9 +72,9 @@
 
 **Deploy su Render**
 
-* Servizi separati: `web` (hosting FE statico o Node che serve `/dist`) e `backend`.
+* Servizio unico Node che builda il frontend (Vite) e serve API + asset statici.
 * **Healthcheck**: `GET /healthz` (liveness) e `GET /readyz` (readiness) → 200 OK.
-* **Env backend** (prod):
+* **Env prod** (tutte nello stesso servizio):
 
   * `DATABASE_URL` (Postgres con `?sslmode=require`)
   * `ACCESS_SECRET`, `REFRESH_SECRET`, `SSO_SECRET`
@@ -83,7 +83,7 @@
   * `VAPID_PUBLIC`, `VAPID_PRIVATE`
   * `SENTRY_DSN`, `CORS_ORIGIN`
   * `BATCH_STRATEGY` (es. `FIFO`), `DB_CA_PATH`, `NODE_EXTRA_CA_CERTS` (opz.)
-* **Env frontend** (prod): `VITE_API_URL`, opzionali `VITE_API_KEY`, `VITE_COMPANY_ID`
+  * `VITE_API_URL` (build-time), opzionali `VITE_API_KEY`, `VITE_COMPANY_ID`
 * No secrets in client; no script postinstall lenti. Auto-deploy da `main` via Deploy Hook.
 
 **CI/CD (GitHub Actions)**

--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ cd ../frontend && npm run dev
 
 ### Render
 
-Deploying on [Render](https://render.com) requires the following configuration:
+Deploying on [Render](https://render.com) (single Node service serving API and frontend) requires the following configuration:
 
 - **Dockerfile path:** `backend/Dockerfile` (build context = repo root)
 - **Health check path:** `/health`
-- **Environment variables:** `DATABASE_URL`, `ACCESS_SECRET`, `REFRESH_SECRET`, `SSO_SECRET`, `API_KEY`, `FILE_ENCRYPTION_KEY`, `ALERT_EMAIL` (optional), `BATCH_STRATEGY` (optional), `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE`, `VAPID_PUBLIC`, `VAPID_PRIVATE`, `SENTRY_DSN`, `CORS_ORIGIN`. If using Supabase pooling (6543) set `SUPABASE_CA_CERT` to the base64 of your DB CA. If using direct (5432), include `?sslmode=require` in `DATABASE_URL`.
+- **Environment variables:** `DATABASE_URL`, `ACCESS_SECRET`, `REFRESH_SECRET`, `SSO_SECRET`, `API_KEY`, `FILE_ENCRYPTION_KEY`, `ALERT_EMAIL` (optional), `BATCH_STRATEGY` (optional), `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE`, `VAPID_PUBLIC`, `VAPID_PRIVATE`, `SENTRY_DSN`, `CORS_ORIGIN`, `VITE_API_URL`. If using Supabase pooling (6543) set `SUPABASE_CA_CERT` to the base64 of your DB CA. If using direct (5432), include `?sslmode=require` in `DATABASE_URL`.
 - **Blueprint (optional):** a starter `render.yaml` is included. You can import it in Render → New + → Blueprint from Repo. Fill secrets after import.
 
 To audit a deployed service with Render API, create a Personal Access Token in Render (Account → API Keys) and run:


### PR DESCRIPTION
## Summary
- clarify Render deployment uses a single Node service
- document combined environment variables including VITE_API_URL

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c6a2274de8832eb16f029b733dd74a