### PR TITLE
Fix storage health check upload path

### DIFF
--- a/backend/src/health.js
+++ b/backend/src/health.js
@@ -109,7 +109,7 @@ async function checkCache() {
 async function checkStorage() {
   try {
     // Use environment variable for upload directory, fallback to relative path
-    const uploadRoot = process.env.UPLOAD_DIR || path.join(__dirname, '..', 'uploads');
+    const uploadRoot = process.env.UPLOAD_DIR || path.join(__dirname, '..', '..', 'uploads');
     
     // Create upload directory if it doesn't exist
     try {


### PR DESCRIPTION
## Summary
- ensure the storage health probe uses the same default upload directory as the storage module, avoiding spurious write failures

## Testing
- npm test -- storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d563165f34832e91e528ac3cf8676f