### PR TITLE
test: update health check response expectation

### DIFF
--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -14,5 +14,17 @@ afterAll((done) => {
 test('GET /health returns ok status', async () => {
   const res = await request(server).get('/health');
   expect(res.status).toBe(200);
-  expect(res.body).toEqual({ status: 'ok' });
+  expect(res.body).toEqual(
+    expect.objectContaining({
+      status: 'healthy',
+      timestamp: expect.any(String),
+      services: expect.objectContaining({
+        database: expect.objectContaining({ status: expect.any(String) }),
+        cache: expect.objectContaining({ status: expect.any(String) }),
+        storage: expect.objectContaining({ status: expect.any(String) }),
+        environment: expect.objectContaining({ status: expect.any(String) })
+      }),
+      system: expect.any(Object)
+    })
+  );
 });


### PR DESCRIPTION
## Summary
- relax the backend health endpoint test to accept the new diagnostics payload

## Testing
- not run (diagnostic change only)


------
https://chatgpt.com/codex/tasks/task_e_68d56207f5a4832e8b5198cedcb53db9